### PR TITLE
Fix parameter name for img mousedown

### DIFF
--- a/js/jquery.twentytwenty.js
+++ b/js/jquery.twentytwenty.js
@@ -78,7 +78,7 @@
         }
       });
 
-      container.find("img").on("mousedown", function(e) {
+      container.find("img").on("mousedown", function(event) {
         event.preventDefault();
       });
 


### PR DESCRIPTION
Fixes possible exception with img mousedown event because the parameter name was incorrect.
