### PR TITLE
Fixes a styling issue

### DIFF
--- a/js/jquery.twentytwenty.js
+++ b/js/jquery.twentytwenty.js
@@ -33,8 +33,8 @@
         return {
           w: w+"px",
           h: h+"px",
-          cw: (dimensionPct*w)+"px",
-          ch: (dimensionPct*h)+"px"
+          cw: Math.round(dimensionPct*w)+"px",
+          ch: Math.round(dimensionPct*h)+"px"
         };
       };
 


### PR DESCRIPTION
This fixes a styling issue in Google Chrome (and probably other webkit based browsers) in case the calculation returns uneven numbers.

I experieced a styling bug with this when I modified the handle to look a bit different. When the page was loaded, elements within the handle (normally the arrows) were 1px off from the position where they were when I started to move the handle. This seemed to fix the issue.