### PR TITLE
Workaround to avoid scrolling on iOS devices

### DIFF
--- a/js/jquery.twentytwenty.js
+++ b/js/jquery.twentytwenty.js
@@ -98,6 +98,8 @@
         event.preventDefault();
       });
 
+      slider.on("touchmove", function(event) {});
+
       $(window).trigger("resize.twentytwenty");
     });
   };


### PR DESCRIPTION
This will avoid the scrolling triggered by sliding as described in #68.
Seems to work, however it does not seem to be a clean solution to the
problem.