### PR TITLE
Add move and click anywhere options to control slider

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ $(function(){
     orientation: 'vertical', // Orientation of the before and after images ('horizontal' or 'vertical')
     before_label: 'January 2017', // Set a custom before label
     after_label: 'March 2017', // Set a custom after label
-    no_overlay: true //Do not show the overlay with before and after
+    no_overlay: true, //Do not show the overlay with before and after
+    move_with_handle_only: true, // Allow a user to swipe anywhere on the image to control slider movement. 
+    click_to_move: false // Allow a user to click (or tap) anywhere on the image to move the slider to that location.
   });
 });
 ```


### PR DESCRIPTION
Default slider control behavior remains the same as it did previously.
A consumer of this plugin must enable these options for the control
behavior to change.