### PR TITLE
Disabled finding overlay container

### DIFF
--- a/js/jquery.twentytwenty.js
+++ b/js/jquery.twentytwenty.js
@@ -24,6 +24,9 @@
       container.wrap("<div class='twentytwenty-wrapper twentytwenty-" + sliderOrientation + "'></div>");
       if(!options.no_overlay) {
         container.append("<div class='twentytwenty-overlay'></div>");
+        var overlay = container.find(".twentytwenty-overlay");
+        overlay.append("<div class='twentytwenty-before-label' data-content='"+options.before_label+"'></div>");
+        overlay.append("<div class='twentytwenty-after-label' data-content='"+options.after_label+"'></div>");
       }
       var beforeImg = container.find("img:first");
       var afterImg = container.find("img:last");
@@ -34,11 +37,7 @@
       container.addClass("twentytwenty-container");
       beforeImg.addClass("twentytwenty-before");
       afterImg.addClass("twentytwenty-after");
-
-      var overlay = container.find(".twentytwenty-overlay");
-      overlay.append("<div class='twentytwenty-before-label' data-content='"+options.before_label+"'></div>");
-      overlay.append("<div class='twentytwenty-after-label' data-content='"+options.after_label+"'></div>");
-
+      
       var calcOffset = function(dimensionPct) {
         var w = beforeImg.width();
         var h = beforeImg.height();


### PR DESCRIPTION
When used with `no_overlay:true`, allows for custom overlay to be hardcoded within HTML markup without original overlay being shown.