### PR TITLE
Remove usage of :first, :last (deprecated in jQuery 3.4.0)

### DIFF
--- a/js/jquery.twentytwenty.js
+++ b/js/jquery.twentytwenty.js
@@ -28,8 +28,9 @@
         overlay.append("<div class='twentytwenty-before-label' data-content='"+options.before_label+"'></div>");
         overlay.append("<div class='twentytwenty-after-label' data-content='"+options.after_label+"'></div>");
       }
-      var beforeImg = container.find("img:first");
-      var afterImg = container.find("img:last");
+      var images = container.find("img");
+      var beforeImg = images.first();
+      var afterImg = images.last();
       container.append("<div class='twentytwenty-handle'></div>");
       var slider = container.find(".twentytwenty-handle");
       slider.append("<span class='twentytwenty-" + beforeDirection + "-arrow'></span>");


### PR DESCRIPTION
Ref #108

http://blog.jquery.com/2019/04/10/jquery-3-4-0-released/

> Specifically, jQuery 3.4.0 is deprecating :first, :last, :eq, :even, :odd, :lt, :gt, and :nth. When we remove Sizzle, we’ll replace it with a small wrapper around querySelectorAll, and it would be almost impossible to reimplement these selectors without a larger selector engine.
> 
> We think this trade-off is worth it. Keep in mind we will still support the positional methods, such as .first, .last, and .eq. Anything you can do with positional selectors, you can do with positional methods instead. They perform better anyway.